### PR TITLE
Implement std::error::Error for all error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 
+use core::fmt;
 use core::{borrow::Borrow, marker::PhantomData};
 
 #[cfg(feature = "alloc")]
@@ -73,6 +74,18 @@ where
         ReadParsedError::ParseErr(value)
     }
 }
+
+impl<ReadErr> fmt::Display for ReadParsedError<ReadErr>
+where
+    ReadErr: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<ReadErr> std::error::Error for ReadParsedError<ReadErr> where ReadErr: core::fmt::Debug {}
 
 // ===========================================================================
 // ===========================================================================

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -102,7 +102,10 @@
 //!
 //!
 
-use core::{fmt::Debug, ops::Deref};
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
 use tlf::TypeLengthField;
 
@@ -136,6 +139,15 @@ pub enum ParseError {
     /// Got a variant id that isn't known. This means it's either invalid or not supported (yet) by the parser
     UnexpectedVariant,
 }
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as Debug>::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {}
 
 type ResTy<'i, O> = Result<(&'i [u8], O), ParseError>;
 #[allow(dead_code)]

--- a/src/parser/tlf.rs
+++ b/src/parser/tlf.rs
@@ -1,5 +1,7 @@
 //! A Type-Length-Field is a building block for many SML data structures.
 
+use core::fmt;
+
 use crate::parser::ParseError;
 
 use super::{take_byte, SmlParse};
@@ -26,6 +28,15 @@ impl From<TlfParseError> for ParseError {
         ParseError::InvalidTlf(x)
     }
 }
+
+impl fmt::Display for TlfParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TlfParseError {}
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct TypeLengthField {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -32,7 +32,7 @@ mod decoder_reader;
 
 pub use decoder_reader::{DecoderReader, ReadDecodedError};
 
-use core::borrow::Borrow;
+use core::{borrow::Borrow, fmt};
 
 use crate::util::{Buffer, OutOfMemory, CRC_X25};
 
@@ -284,6 +284,15 @@ pub enum DecodeErr {
         num_padding_bytes: u8,
     },
 }
+
+impl fmt::Display for DecodeErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeErr {}
 
 #[derive(Debug)]
 enum DecodeState {

--- a/src/transport/decoder_reader.rs
+++ b/src/transport/decoder_reader.rs
@@ -1,5 +1,7 @@
 //! module containing the `DecodeReader` and related implementation
 
+use core::fmt;
+
 use super::{DecodeErr, Decoder};
 use crate::util::{Buffer, ByteSource, ByteSourceErr};
 
@@ -13,6 +15,15 @@ pub enum ReadDecodedError<IoErr> {
     /// (inner_error, num_discarded_bytes)
     IoErr(IoErr, usize),
 }
+
+impl fmt::Display for ReadDecodedError<fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ReadDecodedError<fmt::Error> {}
 
 /// Decode transmissions read from a byte source
 pub struct DecoderReader<B, R>


### PR DESCRIPTION
This PR implements `std::error::Error` for all error types matching the Regex `pub \w+ \w+Err`: `ReadParsedError`, `DecodeErr`, `ParseError`, `TlfParseError`, `ReadDecodedError`. Therefore, `core::fmt::Display` is also implemented for all these types.

Closes https://github.com/felixwrt/sml-rs/issues/19