### PR TITLE
refactor `ByteSourceErr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Decoder improvements (#43)
 - **BREAKING:** Renamed `*Reader` types to `*ByteSource` (e.g. `IoReader` to `IoByteSource`) (#45)
+- Refactored `ByteSourceErr` trait (#46)
 
 
 ## [0.4.0] - 2024-06-04


### PR DESCRIPTION
Refactor `ByteSourceErr` such that it cannot be `is_eof` and `is_would_block` at the same time.